### PR TITLE
insert new webpack entries as hash instead of array.

### DIFF
--- a/src/framework.js
+++ b/src/framework.js
@@ -18,7 +18,7 @@ function createAndStartDevServer (getApp, options) {
 function createWebpackCompiler (config) {
   config.entry['webpack_hm_client'] = 'webpack-hot-middleware/client?path=' + config.output.publicPath + '__webpack_hmr';
   if (typeof config.plugins === 'undefined') config.plugins = []
-  config.plugins['webpack_hmr_plugin'] = new webpack.HotModuleReplacementPlugin();
+  config.plugins.unshift(new webpack.HotModuleReplacementPlugin());
   return webpack(config)
 }
 

--- a/src/framework.js
+++ b/src/framework.js
@@ -15,8 +15,8 @@ function createAndStartDevServer (getApp, options) {
 }
 
 function createWebpackCompiler (config) {
-  config.entry.unshift('webpack-hot-middleware/client')
-  config.plugins.unshift(new webpack.HotModuleReplacementPlugin())
+  config.entry['webpack_hm_client'] = 'webpack-hot-middleware/client';
+  config.plugins['webpack_hmr_plugin'] = new webpack.HotModuleReplacementPlugin();
   return webpack(config)
 }
 


### PR DESCRIPTION
webpack has redefined multiple entries as hash. https://webpack.github.io/docs/multiple-entry-points.html. This commit will reallow multiple entries to be inserted as hash and not get an error when new entries are unshifted in.
